### PR TITLE
update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ but it can suit other use-cases as it implements a usual Map API.
 
 ## Install
 
-`npm install --save WeakTupleMap`
+`npm install --save weaktuplemap`
 
 This lib has no dependency, but requires a native implementation of WeakMap.
 


### PR DESCRIPTION
I can't seem to find WeakTupleMap on npm.